### PR TITLE
Switch comment syntax style

### DIFF
--- a/data/pdfa/htmlstylesheet-override.scss
+++ b/data/pdfa/htmlstylesheet-override.scss
@@ -1,5 +1,5 @@
 :root {
-  --ribose-primary-color: #d03f4e; // PDFa logo red. Required for WCAG Level AA colour contrast
+  --ribose-primary-color: #d03f4e; /* PDFa logo red. Required for WCAG Level AA colour contrast */
 }
 
 .logo {
@@ -17,21 +17,21 @@
 }
 
 .coverpage-container {
-  line-height: 1.5; // WCAG Level AA recommends 1.5 line height as a minimum
+  line-height: 1.5; /* WCAG Level AA recommends 1.5 line height as a minimum */
 }
 
 #toc li a, #toc > ul :is(.h1, .h2, .h3, .h4, .h5, .h6) li a {
-  text-transform: none; // PDF is case-sensitive! Never force uppercase! 
+  text-transform: none; /* PDF is case-sensitive! Never force uppercase! */
 }
 
 h1, .h1 {
-  text-transform: none; // PDF is case-sensitive! Never force uppercase! 
+  text-transform: none; /* PDF is case-sensitive! Never force uppercase! */
 }
 
 .example .example-title {
-  text-transform: none; // PDF is case-sensitive! Never force uppercase! 
+  text-transform: none; /* PDF is case-sensitive! Never force uppercase! */
 }
 
 a {
-  text-decoration: underline; // WCAG - all links must be clearly visible
+  text-decoration: underline; /* WCAG - all links must be clearly visible */
 }


### PR DESCRIPTION
Comments were making their way to HTML which caused syntax errors. 
They shouldn't have, according to https://sass-lang.com/documentation/syntax/comments/
