### PR TITLE
Restore gated-direct release.yml (revert wrapper routing)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,10 @@ on:
 
 jobs:
   release:
-    uses: metanorma/support/.github/workflows/release.yml@main
+    uses: metanorma/ci/.github/workflows/rubygems-release.yml@main
     with:
       next_version: ${{ github.event.inputs.next_version }}
     secrets:
       rubygems-api-key: ${{ secrets.METANORMA_CI_RUBYGEMS_API_KEY }}
+      pat_token: ${{ secrets.METANORMA_CI_PAT_TOKEN }}
 


### PR DESCRIPTION
Restores `metanorma-taste`'s `release.yml` from the `metanorma/support` wrapper back to the gated-direct release path: routes through `metanorma/ci/.github/workflows/rubygems-release.yml@main`, forwarding both `rubygems-api-key` and `pat_token`.

## Why

The gated-direct release model (the test-gated re-architecture plus the 2026-06-11/06-12 fixes) is now verified working end-to-end via the `html2doc` 1.11.1 canary (2026-06-18). The `metanorma/support` wrapper was a parallel approach that has been stood down; `metanorma-taste` was the only gem left routing through it. This brings it back in line with the rest of the org and matches the reverted cimas master template.

No functional regression: taste's `rake.yml` already triggers on tag pushes, so the gated relay (`workflow_dispatch` bump+tag → tests → `do-release` → publish) works exactly as for every other gated-direct gem.

🤖
