### PR TITLE
Add first-class bibliography-sort taste config

### DIFF
--- a/data/oiml/config.yaml
+++ b/data/oiml/config.yaml
@@ -16,6 +16,16 @@ base-override:
     #presentation-metadata-backcover-text: expresslang.org
     output-extensions: xml,html,pdf,doc
     fonts: Futura PT Book;Futura PT Demi;Futura PT Light
+  bibliography-sort:
+  - abbrev: OIML
+    rank: 1
+    name: International Organization of Legal Metrology
+  - abbrev: ISO
+    rank: 2
+    name: International Organization for Standardization
+  - abbrev: IEC
+    rank: 3
+    name: International Electrotechnical Commission
 doctypes:
   # OIML G
 - taste: international-guide

--- a/lib/metanorma/taste/base.rb
+++ b/lib/metanorma/taste/base.rb
@@ -145,6 +145,7 @@ module Metanorma
         # Add attributes from different sources
         add_file_based_overrides(override_attrs)
         add_base_configuration_overrides(override_attrs, attrs)
+        add_bibliography_sort_overrides(override_attrs)
         apply_doctype_overrides(attrs, override_attrs)
         apply_stage_overrides(attrs, override_attrs)
         apply_committee_overrides(attrs, override_attrs)
@@ -251,6 +252,19 @@ module Metanorma
           value or next
           value += add_base_configuration_additive(config_key, attr_key, attrs)
           override_attrs << ":#{attr_key}: #{value}"
+        end
+      end
+
+      # Emit the publisher bibliography sort order as
+      # :sort-biblio-<abbrev>: <rank>: <name> document attributes, one per
+      # configured publisher. The shared Metanorma::Standoc::Ref sort helpers
+      # read these to override the base flavour's built-in publisher ranking.
+      def add_bibliography_sort_overrides(override_attrs)
+        items = @config.base_override&.bibliography_sort or return
+        items.each do |item|
+          item.abbrev.to_s.empty? and next
+          override_attrs <<
+            ":sort-biblio-#{item.abbrev}: #{item.rank}: #{item.name}"
         end
       end
 

--- a/lib/metanorma/taste/base_override.rb
+++ b/lib/metanorma/taste/base_override.rb
@@ -3,6 +3,7 @@
 require "lutaml/model"
 require_relative "filename_attributes"
 require_relative "value_attributes"
+require_relative "biblio_sort_item"
 
 module Metanorma
   module Taste
@@ -11,10 +12,12 @@ module Metanorma
     class BaseOverride < Lutaml::Model::Serializable
       attribute :filename_attributes, FilenameAttributes
       attribute :value_attributes, ValueAttributes
+      attribute :bibliography_sort, BiblioSortItem, collection: true
 
       key_value do
         map "filename-attributes", to: :filename_attributes
         map "value-attributes", to: :value_attributes
+        map "bibliography-sort", to: :bibliography_sort
       end
     end
   end

--- a/lib/metanorma/taste/biblio_sort_item.rb
+++ b/lib/metanorma/taste/biblio_sort_item.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "lutaml/model"
+
+module Metanorma
+  module Taste
+    # Model for a single publisher bibliography sort-rank entry. A taste lists
+    # these to override the base flavour's built-in publisher sort order for the
+    # bibliography (e.g. OIML ranks OIML ahead of ISO/IEC). Each entry compiles
+    # to a :sort-biblio-<abbrev>: <rank>: <name> document attribute, consumed by
+    # the shared Metanorma::Standoc::Ref sort helpers.
+    class BiblioSortItem < Lutaml::Model::Serializable
+      attribute :abbrev, :string
+      attribute :name, :string
+      attribute :rank, :integer
+
+      key_value do
+        map "abbrev", to: :abbrev
+        map "name", to: :name
+        map "rank", to: :rank
+      end
+    end
+  end
+end

--- a/spec/metanorma/taste/biblio_sort_spec.rb
+++ b/spec/metanorma/taste/biblio_sort_spec.rb
@@ -1,0 +1,57 @@
+require_relative "../../spec_helper"
+require "metanorma/taste/base"
+
+RSpec.describe Metanorma::Taste::Base do
+  describe "#add_bibliography_sort_overrides" do
+    let(:test_directory) { "/path/to/test/directory" }
+    let(:config) { Metanorma::Taste::TasteConfig.from_yaml(yaml_config) }
+    let(:base) { described_class.new(:test, config, directory: test_directory) }
+
+    context "with a bibliography-sort config" do
+      let(:yaml_config) do
+        <<~YAML
+          flavor: test
+          owner: Test Organization
+          base-flavor: iso
+          base-override:
+            bibliography-sort:
+            - abbrev: OIML
+              rank: 1
+              name: International Organization of Legal Metrology
+            - abbrev: ISO
+              rank: 2
+              name: International Organization for Standardization
+            - abbrev: IEC
+              rank: 3
+              name: International Electrotechnical Commission
+        YAML
+      end
+
+      it "emits one :sort-biblio-<abbrev>: <rank>: <name> per publisher" do
+        override_attrs = []
+        base.send(:add_bibliography_sort_overrides, override_attrs)
+        expect(override_attrs).to eq [
+          ":sort-biblio-OIML: 1: International Organization of Legal Metrology",
+          ":sort-biblio-ISO: 2: International Organization for Standardization",
+          ":sort-biblio-IEC: 3: International Electrotechnical Commission",
+        ]
+      end
+    end
+
+    context "when bibliography-sort is absent" do
+      let(:yaml_config) do
+        <<~YAML
+          flavor: test
+          owner: Test Organization
+          base-flavor: iso
+        YAML
+      end
+
+      it "adds no override attributes" do
+        override_attrs = []
+        base.send(:add_bibliography_sort_overrides, override_attrs)
+        expect(override_attrs).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
Refs https://github.com/metanorma/metanorma-oiml/issues/12

New first-class `bibliography-sort` config (abbrev/rank/name per publisher) compiling to `:sort-biblio-<abbrev>:` document attributes, letting a taste override a flavour's built-in publisher sort. OIML taste wired to rank OIML ahead of ISO/IEC.

Part of the stack-wide configurable bibliography publisher-sort feature. The bibliography's publisher sort order becomes overridable via `:sort-biblio-<abbrev>: <rank>: <name>` document attributes — set directly in a document, or injected by a metanorma-taste config. Full diagnosis, design, per-gem breakdown and verification are on the ticket.

🤖
