### PR TITLE
pdfa: surface taste stage abbreviation in docidentifier and cover page

### DIFF
--- a/data/pdfa/config.yaml
+++ b/data/pdfa/config.yaml
@@ -22,7 +22,7 @@ base-override:
     fonts: Source Sans 3;Source Sans 3 SemiBold;Source Sans Pro
     output-extensions: xml,html,pdf
     toclevels-html: 6
-    docidentifier: '{{ doctype_abbr }}-{{ docnumeric | prepend: "000" | slice: -3,3 }} {% if draft %}v{{ draft }}{% endif %} {% if edition %}ed. {{ edition }}{% endif %}'
+    docidentifier: '{{ doctype_abbr }}-{{ docnumeric | prepend: "000" | slice: -3,3 }}{% if bibdata.status.stage.abbreviation %}-{{ bibdata.status.stage.abbreviation }}{% endif %} {% if draft %}v{{ draft }}{% endif %} {% if edition %}ed. {{ edition }}{% endif %}'
 doctypes:
 - taste: specification # Specification # The name goes into i18n.yaml
   base: standard

--- a/data/pdfa/htmlcoverpage.html
+++ b/data/pdfa/htmlcoverpage.html
@@ -39,7 +39,7 @@
 
   <div class="docidentifier">
     <p><b>
-    {{doctype_display}} : {{ docnumber }} {%if stage_display %} - <span style="color:red">{{stage_display}}</span>{% endif %}
+    {{doctype_display}} : {{ docnumber }} {%if stage_display %} - <span style="color:red">{{stage_display}}{% if bibdata.status.stage.abbreviation %} ({{ bibdata.status.stage.abbreviation }}){% endif %}</span>{% endif %}
     </b></p>
   </div>
   <hr/>


### PR DESCRIPTION
Refs https://github.com/metanorma/metanorma-pdfa/issues/24

Surfaces the pdfa taste stage abbreviation (`RC` etc.) in the docidentifier and on the HTML cover page, via the `bibdata` Liquid object from https://github.com/metanorma/isodoc/pull/816. No effect until that isodoc lands (conditionals render empty); no effect on published documents. Narrative on the ticket.

🤖
