### PR TITLE
validate input stages against the taste repertoire; advertise docstage-valid

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -604,6 +604,30 @@ These include:
 * `doctype`: mapping of taste doctypes to native base flavor doctypes
 * `stage`: mapping of taste stages to native base flavor stages
 
+=== Stage repertoire contract
+
+When a taste defines `stages:`, its stage repertoire supersedes the base
+flavor's: input stages are validated against the taste's stage names, an
+unrecognised stage is reported and replaced with the taste's default stage,
+and the base stages the taste maps to are advertised to the flavor as valid
+(through the `:docstage-valid:` document attribute), so the flavor does not
+report them as unrecognised in turn.
+
+The `base:` values of taste stages must respect the base flavor's native
+stage semantics:
+
+* For flavors with free-form stage names (Metanorma Generic and its
+  derivatives, such as Ribose), any string is acceptable as a `base:` stage;
+  draft-ness is controlled by the `published:` flag of the stage.
+* For flavors whose machinery interprets stage values — above all ISO, where
+  document identifiers (pubid) and cover/boilerplate logic are keyed to the
+  numeric harmonized stage codes — `base:` values must be drawn from the
+  flavor's native repertoire (for ISO: numeric stage codes such as `30`,
+  `60`). A stage the flavor cannot interpret will degrade identifier
+  generation to a warning (the taste's own docidentifier template is used
+  instead), but stage-keyed rendering logic will treat the document as a
+  draft.
+
 
 == Data model
 

--- a/lib/metanorma/taste/stage.rb
+++ b/lib/metanorma/taste/stage.rb
@@ -15,12 +15,14 @@ module Metanorma
       # @param attrs [Array<String>] The attributes array (modified in place)
       # @param override_attrs [Array<String>] Array to append override attributes to
       def apply_stage_overrides(attrs, override_attrs)
+        add_valid_stages_attribute(override_attrs)
         stage_index = find_stage_attribute_index(attrs)
         stage_index ||= insert_default_stage(attrs)
         return unless stage_index
 
         current_stage = extract_stage_value(attrs[stage_index])
-        stage_config = find_stage_configuration(current_stage)
+        stage_config = find_stage_configuration(current_stage) ||
+          fallback_stage_configuration(current_stage)
         return unless stage_config
 
         # Transform the stage attribute
@@ -28,6 +30,40 @@ module Metanorma
 
         # Add stage-specific overrides
         add_stage_specific_overrides(override_attrs, stage_config)
+      end
+
+      # Advertise the base stages this taste can emit, as the
+      # :docstage-valid: document attribute: when a taste defines
+      # stages, its repertoire supersedes the base flavour's for stage
+      # validation (the flavour would otherwise warn about the mapped
+      # base stages as unrecognised).
+      #
+      # @param override_attrs [Array<String>] Array to append override attributes to
+      def add_valid_stages_attribute(override_attrs)
+        bases = @config.stages&.map(&:base)&.compact&.uniq
+        bases.nil? || bases.empty? and return
+        override_attrs << ":docstage-valid: #{bases.join(',')}"
+      end
+
+      # A stage not in the taste's repertoire: the taste's stages
+      # supersede the base flavour's, so warn and fall back to the
+      # taste's default stage (nil if none is flagged default, in which
+      # case the unknown stage passes through unchanged).
+      #
+      # @param current_stage [String] The unrecognised input stage
+      # @return [StageConfig, nil] The default stage configuration
+      def fallback_stage_configuration(current_stage)
+        @config.stages.nil? || @config.stages.empty? and return nil
+        warn_unrecognised_stage(current_stage)
+        @config.stages.detect { |dt| dt.default == "true" }
+      end
+
+      # Kernel#warn, not Metanorma::Util.log: the latter goes to stdout
+      # and only when Metanorma.configuration.logs opts into :warning,
+      # which would silently swallow a validation warning.
+      def warn_unrecognised_stage(stage)
+        warn "[metanorma-taste] WARNING: #{stage} is not a recognised " \
+             "status for taste #{@flavor}; reverting to default stage"
       end
 
       # Find the index of the stage attribute in the attributes array

--- a/spec/metanorma/taste_register_spec.rb
+++ b/spec/metanorma/taste_register_spec.rb
@@ -399,6 +399,25 @@ RSpec.describe Metanorma::TasteRegister do
       expect(result2).to include(":presentation-metadata-stage-alias: release-candidate")
       expect(result2).to include(":docstage-abbrev: RC")
       expect(result2).not_to include(":docstage-published: true")
+      # the taste advertises its stage repertoire to the base flavour
+      expect(result2).to include(":docstage-valid: draft,published")
+    end
+
+    it "warns and falls back to the default stage on an unrecognised stage" do
+      result = nil
+      expect do
+        result = taste2
+          .process_input_adoc_overrides(attrs2.dup + [":docstage: working-draft"],
+                                        options)
+      end.to output(/working-draft is not a recognised status for taste pdfa/)
+        .to_stderr_from_any_process
+      # the taste's stage repertoire supersedes the base flavour's:
+      # working-draft is a ribose stage but not a pdfa one
+      expect(result).to include(":docstage: published")
+      expect(result).to include(":docstage-published: true")
+      expect(result).to include(":presentation-metadata-stage-alias: published")
+      expect(result).to include(":docstage-valid: draft,published")
+      expect(result).not_to include(":docstage: working-draft")
     end
 
     it "generates output with the correct boilerplate path" do


### PR DESCRIPTION
Refs https://github.com/metanorma/metanorma-pdfa/issues/24

Part of the taste stage-repertoire takeover: tastes validate input stages against their own repertoire and advertise the mapped base stages to the flavour as `:docstage-valid:`, which supersedes the flavour's recognised-stage list. Companion PRs in metanorma-standoc, metanorma-generic, metanorma-taste, isodoc, metanorma-ieee, metanorma-nist, metanorma-iso; release metanorma-standoc first, metanorma-taste last. Full narrative on the ticket.

🤖
