### PR TITLE
feat(oiml): add OIML-CS doctypes (PD, OD, CID)

### DIFF
--- a/data/oiml/config.yaml
+++ b/data/oiml/config.yaml
@@ -48,3 +48,12 @@ doctypes:
   # OIML S
 - taste: seminar-report
   base: international-standard
+  # OIML-CS PD
+- taste: oiml-cs-procedural-document
+  base: international-standard
+  # OIML-CS OD
+- taste: oiml-cs-operational-document
+  base: international-standard
+  # OIML-CS CID
+- taste: oiml-cs-clarification-document
+  base: international-standard


### PR DESCRIPTION
## Summary

Adds three new OIML-CS doctypes to the OIML taste config:

- `oiml-cs-procedural-document` (OIML-CS PD — Procedural Documents)
- `oiml-cs-operational-document` (OIML-CS OD — Operational Documents)
- `oiml-cs-clarification-document` (OIML-CS CID — Clarifications & Interpretations Documents)

These are operational sub-publications of the OIML Certification System, governed by OIML B 18 (Framework for the OIML-CS). They are distinct from OIML D (International Document) and currently have no dedicated doctype — see issue for OIML-CS logo support.

## Test plan

- [x] `bundle exec ruby -Ilib -e 'require "metanorma/taste"; ...'` confirms all 10 doctypes load cleanly
- [x] `bundle exec rspec spec/metanorma/config_validation_spec.rb` — 22 examples, 0 failures