### PR TITLE
fix(enosema): specify Source Sans 3 to avoid broken webcore-fonts formula

### DIFF
--- a/data/enosema/config.yaml
+++ b/data/enosema/config.yaml
@@ -13,6 +13,7 @@ base-override:
     presentation-metadata-color-secondary: '#007724'
     presentation-metadata-backcover-text: enosema.org
     output-extensions: xml,html,pdf,doc
+    fonts: Source Sans 3
 doctypes:
 - taste: standard
   base: international-standard

--- a/spec/metanorma/taste_register_spec.rb
+++ b/spec/metanorma/taste_register_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Metanorma::TasteRegister do
       # inherited from oiml
       expect(cfg.base_flavor).to eq("iso")
       expect(cfg.base_override.value_attributes.fonts)
-        .to eq("Futura PT Book;Futura PT Demi;Futura PT Light")
+        .to eq("Jost;Jost SemiBold;Jost Light")
       expect(cfg.base_override.value_attributes.output_extensions)
         .to include("pdf")
       # overridden by oiml-cs


### PR DESCRIPTION
## Summary

- Fixes the failing `compiles blank document for enosema taste` spec on ubuntu-latest (and now macos-latest on `main`).
- Root cause: the enosema taste inherits the `iso` base flavor's default font list, which makes fontist try to install fonts via the **`webcore-fonts`** formula. That formula's mirrors are dead:
  - `ftp.lysator.liu.se` → 500
  - `download.opensuse.org/repositories/home:/alteratio:/Common/openSUSE_13.2/` → 404 (repo removed)
  - `plug-mirror.rcac.purdue.edu` → 404
  - `web.archive.org` fallback → SHA256 checksum mismatch
- Fix: specify `fonts: Source Sans 3` on the enosema taste so fontist no longer falls back to webcore-fonts. Source Sans 3 is the same reliable Google Font already used by the `elf` and `pdfa` tastes.

Also folds in a one-line fix for a regression introduced between PR #179 and PR #182: the `oiml-cs` inherited-fonts pin still expected the old Futura stack while the config now ships Jost. PR #182 branched off main before PR #179 added the spec, so the expectation drifted.

## Files changed

- `data/enosema/config.yaml` — one new line: `fonts: Source Sans 3` under `value-attributes`.
- `spec/metanorma/taste_register_spec.rb` — expectation updated from `"Futura PT Book;Futura PT Demi;Futura PT Light"` to `"Jost;Jost SemiBold;Jost Light"`.

## Test plan

- [x] `bundle exec rspec spec/metanorma/compile_spec.rb -e enosema` — 1 example, 0 failures (was failing before).
- [x] `bundle exec rspec spec/metanorma/taste_register_spec.rb spec/metanorma/config_validation_spec.rb` — 54 examples, 0 failures.
- [ ] CI: all `rake / Test on Ruby X` jobs pass.

## Notes

- This is a repo-local workaround for an upstream fontist issue (`fontist/formulas` webcore formula pointing at dead openSUSE mirrors). A separate upstream fix would still be valuable but isn't blocking.
- If EFS has an official brand font, swap `Source Sans 3` for it in a follow-up.
