### PR TITLE
Per-taste document_transformers hook + OIML STS output format

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -793,6 +793,46 @@ taste = Metanorma::TasteRegister.get(:acme)
 # Returns an instance of Metanorma::Taste::Acme
 ----
 
+=== Document-model output transformers
+
+Besides config overrides, a taste can contribute a document-model *output
+format* — a reader + transformer that the taste-aware metanorma-core `Processor`
+drives. This is how the OIML taste produces STS output through the pipeline
+(`metanorma compile -t oiml -x oimlsts`) instead of a standalone tool.
+
+Two pieces:
+
+. Add the format symbol to the taste's `output-extensions` in
+`data/<taste>/config.yaml` (under `base-override.value-attributes`), so it is
+selectable at compile time.
+
+. Add an optional `data/<taste>/transformers.rb` shim that registers the
+transformer spec. It is discovered and required *lazily* — only when a build of
+that taste resolves its output formats — so the artefact gem loads only for that
+taste, and metanorma-taste keeps no hard dependency on it:
+
+[source,ruby]
+----
+Metanorma::TasteRegister.register_document_transformers(:acme) do
+  require "metanorma/acme/sts"          # lazy: loaded only for :acme builds
+  {
+    acmests: {
+      reader: Metanorma::Acme::Sts::Reader,        # .from_xml(String) -> model
+      transformer: Metanorma::Acme::Sts::Standard, # .new(model, opts); #transform -> target#to_xml
+      strip_default_namespace: false,
+      to_xml_options: {},
+      suffix: "acme.sts.xml",   # output filename suffix
+      presentation: true,       # consume presentation XML (vs semantic)
+    },
+  }
+end
+----
+
+The `reader` / `transformer` / `strip_default_namespace` / `to_xml_options` keys
+conform to the metanorma-core `Processor#document_transformers` contract; the
+`suffix` / `presentation` keys are read by the Metanorma compile driver to make
+the format selectable and pick its input leg.
+
 === Taste code
 
 * Must be unique among all tastes

--- a/data/oiml/config.yaml
+++ b/data/oiml/config.yaml
@@ -14,7 +14,7 @@ base-override:
     publisher_abbr: OIML
     #presentation-metadata-color-secondary: '#3f65a2'
     #presentation-metadata-backcover-text: expresslang.org
-    output-extensions: xml,html,pdf,doc
+    output-extensions: xml,html,pdf,doc,oimlsts
     fonts: Jost;Jost SemiBold;Jost Light
   bibliography-sort:
   - abbrev: OIML

--- a/data/oiml/transformers.rb
+++ b/data/oiml/transformers.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Per-taste document-model transformer registration for the OIML taste.
+#
+# Discovered and required lazily by Metanorma::TasteRegister the first time an
+# OIML build resolves its output formats. The `require` below therefore loads
+# metanorma-oiml only for OIML builds, and metanorma-taste keeps no hard
+# dependency on metanorma-oiml.
+#
+# The returned spec conforms to the metanorma-core
+# Processor#document_transformers contract (reader / transformer /
+# strip_default_namespace / to_xml_options), plus two keys the metanorma
+# compile driver reads to make the format selectable (suffix / presentation).
+Metanorma::TasteRegister.register_document_transformers(:oiml) do
+  require "metanorma/oiml/sts"
+
+  {
+    oimlsts: {
+      reader: Metanorma::Oiml::Sts::Transformer::SourceDocument,
+      transformer: Metanorma::Oiml::Sts::Transformer::Standard,
+      strip_default_namespace: false,
+      to_xml_options: {},
+      suffix: "oiml.sts.xml",
+      presentation: true,
+    },
+  }
+end

--- a/lib/metanorma/taste_register.rb
+++ b/lib/metanorma/taste_register.rb
@@ -76,6 +76,41 @@ module Metanorma
       @taste_configs.keys
     end
 
+    # Register a per-taste document-model transformer contribution. Called from
+    # a taste's optional +data/<taste>/transformers.rb+ shim. The block is
+    # evaluated lazily by {#document_transformers_for} and must return a
+    # +{ format_symbol => spec }+ hash conforming to the metanorma-core
+    # +Processor#document_transformers+ contract. Because the block runs lazily,
+    # it may +require+ the gem that provides the transformer classes (e.g.
+    # metanorma-oiml), so that gem loads only for builds that use the taste.
+    def self.register_document_transformers(taste, &block)
+      instance.register_document_transformers(taste, &block)
+    end
+
+    def register_document_transformers(taste, &block)
+      (@transformer_hooks ||= {})[normalize_flavor_name(taste)] = block
+    end
+
+    # The document-model transformer specs contributed by +taste+ (e.g. the
+    # OIML taste's STS transformer), or +{}+ when the taste declares none.
+    # Memoised. The taste's +transformers.rb+ shim is required on first use, so
+    # the artefact gem loads only for a build that uses this taste. The compile
+    # driver forces this on the main thread (resolving output extensions) before
+    # parallel output workers read it.
+    def self.document_transformers_for(taste)
+      instance.document_transformers_for(taste)
+    end
+
+    def document_transformers_for(taste)
+      sym = normalize_flavor_name(taste)
+      @transformer_specs ||= {}
+      return @transformer_specs[sym] if @transformer_specs.key?(sym)
+
+      load_transformer_hook(sym)
+      block = (@transformer_hooks ||= {})[sym]
+      @transformer_specs[sym] = block ? block.call : {}
+    end
+
     # Get detailed information about a specific taste
     #
     # @param flavor [String, Symbol] The flavor name
@@ -388,6 +423,18 @@ module Metanorma
     #
     # @param flavor [Symbol] The flavor name
     # @return [String] The directory path
+    # Require the taste's optional data/<taste>/transformers.rb shim once, if
+    # present; it calls {#register_document_transformers} to register the taste's
+    # document-model transformers.
+    def load_transformer_hook(flavor)
+      path = File.join(config_directory_for(flavor), "transformers.rb")
+      require path if File.exist?(path)
+    rescue LoadError => e
+      raise UnknownTasteError,
+            "Taste #{flavor} declares document transformers but its artefact " \
+            "gem could not be loaded (#{e.message}); add it to your bundle."
+    end
+
     def config_directory_for(flavor)
       @config_directories ||= {}
       @config_directories[flavor] || File.join(data_directory, flavor.to_s)

--- a/spec/metanorma/taste_register_document_transformers_spec.rb
+++ b/spec/metanorma/taste_register_document_transformers_spec.rb
@@ -1,0 +1,43 @@
+require "spec_helper"
+
+# The per-taste document-model transformer hook (metanorma-core#12): a taste may
+# contribute { format => spec } entries that the taste-aware metanorma-core
+# Processor merges into its document_transformers.
+RSpec.describe "Metanorma::TasteRegister document-model transformer hook" do
+  let(:register) { Metanorma::TasteRegister.instance }
+
+  # The hook mutates the shared singleton; snapshot and restore its state.
+  around do |example|
+    hooks = register.instance_variable_get(:@transformer_hooks)&.dup
+    specs = register.instance_variable_get(:@transformer_specs)&.dup
+    example.run
+  ensure
+    register.instance_variable_set(:@transformer_hooks, hooks)
+    register.instance_variable_set(:@transformer_specs, specs)
+  end
+
+  it "returns {} for a taste that registers no transformers" do
+    expect(register.document_transformers_for(:no_such_taste)).to eq({})
+  end
+
+  it "returns what a taste registers, evaluating the block lazily" do
+    evaluated = false
+    register.register_document_transformers(:widget) do
+      evaluated = true
+      { widgetsts: { suffix: "widget.sts.xml", presentation: true } }
+    end
+    expect(evaluated).to be(false)
+    expect(register.document_transformers_for(:widget))
+      .to eq(widgetsts: { suffix: "widget.sts.xml", presentation: true })
+  end
+
+  it "memoises the result so the block runs once" do
+    calls = 0
+    register.register_document_transformers(:widget) do
+      calls += 1
+      {}
+    end
+    2.times { register.document_transformers_for(:widget) }
+    expect(calls).to eq(1)
+  end
+end


### PR DESCRIPTION
Refs https://github.com/metanorma/metanorma-core/issues/12

## ⛔ DRAFT / BLOCKED — do not merge until relaton-2.2 / pubid-2 are live in prod

The generic per-taste hook is backward-compatible, but this PR also switches on
the OIML `:oimlsts` output token, which loads metanorma-oiml — itself gated on the
pre-alpha `relaton-2.2` / `pubid-2` chain (**not released**). Merging before
metanorma-oiml#24 and the live chain would make OIML builds error on `:oimlsts`.
Land together with, or after, the OIML side once the chain is live.

## Summary

Adds a **per-taste document-model transformer hook** so a taste can contribute an
output format driven by the taste-aware metanorma-core `Processor` (not just
config overrides).

- `TasteRegister.register_document_transformers` + `document_transformers_for`
  (memoised); a taste declares its specs in an optional
  `data/<taste>/transformers.rb` shim, **discovered and required lazily** — the
  artefact gem loads only for that taste, so metanorma-taste keeps no hard
  dependency on it.
- **OIML taste wired**: `data/oiml/transformers.rb` registers `:oimlsts`
  (lazy-requiring metanorma-oiml); `data/oiml/config.yaml` adds `oimlsts` to
  `output-extensions`. README documents the mechanism for taste authors.

The generic hook merges/tests on released deps. The **`:oimlsts` format activates
only when metanorma-oiml + the relaton-2.2 / pubid-2 chain are present** (that
chain is not yet live — see metanorma-oiml PR), so it should land together with,
or after, the OIML side.

## Test plan

New `taste_register_document_transformers_spec.rb` **3/0**; full suite **79/0**.

🤖
