### PR TITLE
read taste configs as UTF-8 regardless of process locale

### DIFF
--- a/lib/metanorma/taste_register.rb
+++ b/lib/metanorma/taste_register.rb
@@ -215,7 +215,11 @@ module Metanorma
     # @return [Hash{String => Hash}] flavor => {"hash","content","directory"}
     def collect_raw_taste_configs(taste_directories)
       taste_directories.each_with_object({}) do |dir, acc|
-        content = File.read(File.join(dir, "config.yaml"))
+        # explicit encoding: config files are UTF-8, the process locale may
+        # not be (metanorma-cli sets Encoding.default_external to UTF-8, but
+        # library consumers loading the register directly have no such shield)
+        content = File.read(File.join(dir, "config.yaml"),
+                            encoding: "UTF-8")
         hash = YAML.safe_load(content) || {}
         flavor = (hash["flavor"] || File.basename(dir)).to_s
         acc[flavor] = { "hash" => hash, "content" => content,

--- a/spec/metanorma/taste_register_spec.rb
+++ b/spec/metanorma/taste_register_spec.rb
@@ -515,4 +515,27 @@ RSpec.describe Metanorma::TasteRegister do
        expect(result).to include(":fonts: #{swf_fonts}")
     end
   end
+
+  describe "config reading under a non-UTF-8 locale" do
+    it "reads taste configs as UTF-8 regardless of Encoding.default_external" do
+      dirs = register.send(:find_taste_directories,
+                           register.send(:data_directory))
+      old_enc = Encoding.default_external
+      begin
+        suppress_warnings { Encoding.default_external = Encoding::US_ASCII }
+        expect { register.send(:collect_raw_taste_configs, dirs) }
+          .not_to raise_error
+      ensure
+        suppress_warnings { Encoding.default_external = old_enc }
+      end
+    end
+
+    def suppress_warnings
+      old_verbose = $VERBOSE
+      $VERBOSE = nil
+      yield
+    ensure
+      $VERBOSE = old_verbose
+    end
+  end
 end


### PR DESCRIPTION
Closes https://github.com/metanorma/metanorma-taste/issues/189

`collect_raw_taste_configs` now reads `config.yaml` with explicit UTF-8 encoding, so the register loads under any process locale (previously any non-UTF-8 locale aborted on the oiml config's `é` for consumers not shielded by `exe/metanorma`'s `Encoding.default_external` override). Regression spec forces a US-ASCII `default_external` around the read; red on the old code, green now (suite 32/0 in taste_register_spec).

🤖
